### PR TITLE
feat : add personal details

### DIFF
--- a/lib/modules/authentication/presentation/bloc/personal_details_bloc.dart
+++ b/lib/modules/authentication/presentation/bloc/personal_details_bloc.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class Country {
+  final String name;
+  final String code;
+  final String dialCode;
+  final String flag;
+
+  const Country({
+    required this.name,
+    required this.code,
+    required this.dialCode,
+    required this.flag,
+  });
+}
+
+const List<Country> kCountries = [
+  Country(name: 'Nigeria', code: 'NG', dialCode: '+234', flag: '🇳🇬'),
+  Country(name: 'Ghana', code: 'GH', dialCode: '+233', flag: '🇬🇭'),
+  Country(name: 'Kenya', code: 'KE', dialCode: '+254', flag: '🇰🇪'),
+  Country(name: 'United Kingdom', code: 'GB', dialCode: '+44', flag: '🇬🇧'),
+  Country(name: 'United States', code: 'US', dialCode: '+1', flag: '🇺🇸'),
+  Country(name: 'Ethiopia', code: 'ET', dialCode: '+251', flag: '🇪🇹'),
+];
+
+abstract class PersonalDetailsEvent {}
+
+class CitizenshipChanged extends PersonalDetailsEvent {
+  final Country country;
+  CitizenshipChanged(this.country);
+}
+
+class DialCodeChanged extends PersonalDetailsEvent {
+  final Country country;
+  DialCodeChanged(this.country);
+}
+
+class GenderChanged extends PersonalDetailsEvent {
+  final String gender;
+  GenderChanged(this.gender);
+}
+
+class DobChanged extends PersonalDetailsEvent {
+  final DateTime dob;
+  DobChanged(this.dob);
+}
+
+class PhoneChanged extends PersonalDetailsEvent {
+  final String phone;
+  PhoneChanged(this.phone);
+}
+
+class PersonalDetailsState {
+  final Country? citizenship;
+  final Country? dialCountry;
+  final String? gender;
+  final DateTime? dob;
+  final String phone;
+
+  PersonalDetailsState({
+    this.citizenship,
+    this.dialCountry,
+    this.gender,
+    this.dob,
+    this.phone = '',
+  });
+
+  bool get isValid {
+    return citizenship != null &&
+        gender != null &&
+        dob != null &&
+        dialCountry != null &&
+        phone.trim().length >= 6;
+  }
+
+  PersonalDetailsState copyWith({
+    Country? citizenship,
+    Country? dialCountry,
+    String? gender,
+    DateTime? dob,
+    String? phone,
+  }) {
+    return PersonalDetailsState(
+      citizenship: citizenship ?? this.citizenship,
+      dialCountry: dialCountry ?? this.dialCountry,
+      gender: gender ?? this.gender,
+      dob: dob ?? this.dob,
+      phone: phone ?? this.phone,
+    );
+  }
+}
+
+class PersonalDetailsBloc
+    extends Bloc<PersonalDetailsEvent, PersonalDetailsState> {
+  PersonalDetailsBloc() : super(PersonalDetailsState()) {
+    on<CitizenshipChanged>((event, emit) {
+      emit(state.copyWith(citizenship: event.country));
+    });
+    on<DialCodeChanged>((event, emit) {
+      emit(state.copyWith(dialCountry: event.country));
+    });
+    on<GenderChanged>((event, emit) {
+      emit(state.copyWith(gender: event.gender));
+    });
+    on<DobChanged>((event, emit) {
+      emit(state.copyWith(dob: event.dob));
+    });
+    on<PhoneChanged>((event, emit) {
+      emit(state.copyWith(phone: event.phone));
+    });
+  }
+}

--- a/lib/modules/authentication/presentation/screens/personal_details_screen.dart
+++ b/lib/modules/authentication/presentation/screens/personal_details_screen.dart
@@ -1,0 +1,394 @@
+// lib/modules/authentication/presentation/screens/personal_details_screen.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vestrollmobile/core/navigation/routes_constant.dart';
+import 'package:vestrollmobile/core/utils/app_color_extension.dart';
+import 'package:vestrollmobile/core/utils/app_font_theme_extension.dart';
+import 'package:vestrollmobile/modules/authentication/presentation/bloc/personal_details_bloc.dart';
+import 'package:vestrollmobile/modules/authentication/presentation/widgets/dial_code_modal.dart';
+
+class PersonalDetailsScreen extends StatelessWidget {
+  const PersonalDetailsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => PersonalDetailsBloc(),
+      child: const _PersonalDetailsView(),
+    );
+  }
+}
+
+class _PersonalDetailsView extends StatefulWidget {
+  const _PersonalDetailsView();
+
+  @override
+  State<_PersonalDetailsView> createState() => _PersonalDetailsViewState();
+}
+
+class _PersonalDetailsViewState extends State<_PersonalDetailsView> {
+  final _phoneController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    super.dispose();
+  }
+
+  void _openDialModal(BuildContext ctx, {required bool showDialCode}) {
+    showModalBottomSheet(
+      context: ctx,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder:
+          (_) => DialCodeModal(
+            countries: kCountries,
+            showDialCode: showDialCode,
+            onSelected: (country) {
+              if (showDialCode) {
+                ctx.read<PersonalDetailsBloc>().add(DialCodeChanged(country));
+              } else {
+                ctx.read<PersonalDetailsBloc>().add(
+                  CitizenshipChanged(country),
+                );
+              }
+            },
+          ),
+    );
+  }
+
+  Future<void> _pickDate(BuildContext context) async {
+    final initial = DateTime(1995, 1, 1);
+    final first = DateTime(1900);
+    final last = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: first,
+      lastDate: last,
+    );
+    if (picked != null) {
+      context.read<PersonalDetailsBloc>().add(DobChanged(picked));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveColors =
+        Theme.of(context).extension<ColorSystemExtension>() ??
+        ColorSystemExtension.light();
+    final fonts = Theme.of(context).extension<AppFontThemeExtension>();
+    final effectiveFonts =
+        fonts ??
+        AppFontThemeExtension.fromTextTheme(
+          Theme.of(context).textTheme,
+          Colors.black,
+        );
+
+    return Scaffold(
+      backgroundColor: effectiveColors.bgB0,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 12),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              decoration: BoxDecoration(
+                border: Border.all(color: effectiveColors.strokeSecondary),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.help_outline, size: 16),
+                  const SizedBox(width: 6),
+                  Text('Need Help?', style: effectiveFonts.textSmRegular),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 12),
+          child: Column(
+            children: [
+              // 3-segment progress bar
+              Row(
+                children: List.generate(3, (index) {
+                  return Expanded(
+                    child: Container(
+                      height: 6,
+                      margin: EdgeInsets.only(
+                        right: index < 2 ? 4 : 0,
+                      ), // gap between segments
+                      decoration: BoxDecoration(
+                        color:
+                            index <= 1
+                                ? effectiveColors
+                                    .brandActive // completed segments
+                                : effectiveColors.brandActive.withOpacity(
+                                  0.12,
+                                ), // pending
+                        borderRadius: BorderRadius.circular(3),
+                      ),
+                    ),
+                  );
+                }),
+              ),
+              const SizedBox(height: 18),
+
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Personal Details',
+                  style: effectiveFonts.heading1Bold.copyWith(fontSize: 22),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Please provide your personal details, this will be used to complete your profile.',
+                  style: effectiveFonts.textBaseRegular.copyWith(
+                    fontSize: 14, // smaller font
+                    fontWeight: FontWeight.normal, // unbold
+                    color: effectiveColors.textPrimary.withOpacity(
+                      0.5,
+                    ), // faded
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+
+              Expanded(
+                child: BlocBuilder<PersonalDetailsBloc, PersonalDetailsState>(
+                  builder: (context, state) {
+                    return Form(
+                      key: _formKey,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          InkWell(
+                            key: const Key('citizenship_field'),
+                            onTap:
+                                () => _openDialModal(
+                                  context,
+                                  showDialCode: false,
+                                ),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 14,
+                                vertical: 16,
+                              ),
+                              decoration: BoxDecoration(
+                                color: effectiveColors.bgB0,
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: effectiveColors.gray200,
+                                ),
+                              ),
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      state.citizenship?.name ??
+                                          'Country of citizenship',
+                                      style: effectiveFonts.textBaseRegular
+                                          .copyWith(
+                                            color:
+                                                state.citizenship != null
+                                                    ? effectiveColors
+                                                        .textPrimary
+                                                    : effectiveColors
+                                                        .textSecondary,
+                                          ),
+                                    ),
+                                  ),
+                                  const Icon(Icons.keyboard_arrow_down),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+
+                          DropdownButtonFormField<String>(
+                            key: const Key('gender_field'),
+                            value: state.gender,
+                            decoration: InputDecoration(
+                              hintText: 'Gender',
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 14,
+                              ),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            items: const [
+                              DropdownMenuItem(
+                                value: 'Male',
+                                child: Text('Male'),
+                              ),
+                              DropdownMenuItem(
+                                value: 'Female',
+                                child: Text('Female'),
+                              ),
+                              DropdownMenuItem(
+                                value: 'Other',
+                                child: Text('Other'),
+                              ),
+                            ],
+                            onChanged: (v) {
+                              if (v != null) {
+                                context.read<PersonalDetailsBloc>().add(
+                                  GenderChanged(v),
+                                );
+                              }
+                            },
+                          ),
+                          const SizedBox(height: 12),
+
+                          InkWell(
+                            key: const Key('dob_field'),
+                            onTap: () => _pickDate(context),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 14,
+                                vertical: 16,
+                              ),
+                              decoration: BoxDecoration(
+                                color: effectiveColors.bgB0,
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: effectiveColors.gray200,
+                                ),
+                              ),
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      state.dob == null
+                                          ? 'Date of birth'
+                                          : _formatDate(state.dob!),
+                                      style: effectiveFonts.textBaseRegular
+                                          .copyWith(
+                                            color:
+                                                state.dob != null
+                                                    ? effectiveColors
+                                                        .textPrimary
+                                                    : effectiveColors
+                                                        .textSecondary,
+                                          ),
+                                    ),
+                                  ),
+                                  const Icon(Icons.calendar_today),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+
+                          Row(
+                            children: [
+                              InkWell(
+                                key: const Key('dial_code_button'),
+                                onTap:
+                                    () => _openDialModal(
+                                      context,
+                                      showDialCode: true,
+                                    ),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                    vertical: 12,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: effectiveColors.bgB0,
+                                    borderRadius: BorderRadius.circular(12),
+                                    border: Border.all(
+                                      color: effectiveColors.gray200,
+                                    ),
+                                  ),
+                                  child: Text(
+                                    state.dialCountry != null
+                                        ? '${state.dialCountry!.flag} ${state.dialCountry!.dialCode}'
+                                        : '🇳🇬 +234',
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: TextFormField(
+                                  key: const Key('phone_input'),
+                                  controller: _phoneController,
+                                  keyboardType: TextInputType.phone,
+                                  decoration: const InputDecoration(
+                                    hintText: 'Phone number',
+                                    border: OutlineInputBorder(),
+                                    contentPadding: EdgeInsets.symmetric(
+                                      horizontal: 12,
+                                      vertical: 12,
+                                    ),
+                                  ),
+                                  onChanged:
+                                      (v) => context
+                                          .read<PersonalDetailsBloc>()
+                                          .add(PhoneChanged(v)),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const Spacer(),
+
+                          SizedBox(
+                            width: double.infinity,
+                            height: 52,
+                            child: ElevatedButton(
+                              key: const Key('continue_button'),
+                              onPressed:
+                                  state.isValid
+                                      ? () => context.goNamed(
+                                        RouteConstants.addressDetails,
+                                      )
+                                      : null,
+                              child: const Text('Continue'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor:
+                                    state.isValid
+                                        ? effectiveColors
+                                            .brandActive // purple when valid
+                                        : effectiveColors
+                                            .gray400, // grey when disabled
+                                foregroundColor: Colors.white,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}

--- a/lib/modules/authentication/presentation/widgets/dial_code_modal.dart
+++ b/lib/modules/authentication/presentation/widgets/dial_code_modal.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:vestrollmobile/modules/authentication/presentation/bloc/personal_details_bloc.dart';
+
+class DialCodeModal extends StatefulWidget {
+  final List<Country> countries;
+  final void Function(Country) onSelected;
+  final bool showDialCode;
+  const DialCodeModal({
+    super.key,
+    required this.countries,
+    required this.onSelected,
+    this.showDialCode = true,
+  });
+
+  @override
+  State<DialCodeModal> createState() => _DialCodeModalState();
+}
+
+class _DialCodeModalState extends State<DialCodeModal> {
+  String _query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered =
+        widget.countries.where((c) {
+          final q = _query.toLowerCase();
+          return c.name.toLowerCase().contains(q) ||
+              c.dialCode.toLowerCase().contains(q) ||
+              c.code.toLowerCase().contains(q);
+        }).toList();
+
+    return Container(
+      padding: const EdgeInsets.only(top: 12, left: 16, right: 16, bottom: 24),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(width: 48, height: 4, color: Colors.grey[300]),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('country_search'),
+            decoration: const InputDecoration(
+              prefixIcon: Icon(Icons.search),
+              hintText: 'Search',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+                borderSide: BorderSide.none,
+              ),
+              filled: true,
+              contentPadding: EdgeInsets.symmetric(vertical: 10),
+            ),
+            onChanged: (v) => setState(() => _query = v),
+          ),
+          const SizedBox(height: 12),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: MediaQuery.of(context).size.height * 0.5,
+            ),
+            child: ListView.separated(
+              shrinkWrap: true,
+              itemBuilder: (context, index) {
+                final c = filtered[index];
+                return ListTile(
+                  key: Key('country_item_${c.code}'),
+                  leading: Text(c.flag, style: const TextStyle(fontSize: 20)),
+                  title: Text(c.name),
+                  trailing: widget.showDialCode ? Text(c.dialCode) : null,
+                  onTap: () {
+                    widget.onSelected(c);
+                    Navigator.of(context).pop();
+                  },
+                );
+              },
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemCount: filtered.length,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
##  🚀 Feature: Onboarding Personal Details Screen
#### This PR introduces a complete personal details onboarding screen to the Vestroll Mobile app, enabling users to securely provide personal information required for profile completion.

### ✨ New Features

#### 📄 Personal Details Form

#### Users can provide:

Country of citizenship selection via searchable modal.

Dial code selection with flag emoji and searchable modal.

Gender dropdown selection.

Date of birth picker.

Phone number input prefixed with selected dial code.

📁 Files Added / Modified

Added:
```

lib/modules/authentication/presentation/screens/personal_details_screen.dart – main form screen
lib/modules/authentication/presentation/widgets/dial_code_modal.dart – searchable dial code modal
lib/modules/authentication/presentation/bloc/personal_details_bloc.dart – events & state

Modified:

lib/core/navigation/app_router.dart – added route for /personal-details

```

🧪 Testing
✅ Widget test covers:

Selecting country of citizenship.

Selecting dial code.

Selecting gender.

Selecting date of birth.

Entering phone number.

Enabling continue button once all fields are valid.


 Screenshot
<img width="394" height="866" alt="Screenshot from 2025-10-14 11-17-20" src="https://github.com/user-attachments/assets/9fedfa4e-2130-4501-b5a2-ef86510e0e5e" />
