### PR TITLE
feat(home): finalize home dashboard UI to match Figma design

### DIFF
--- a/lib/modules/homepage/presentation/screens/home_screen.dart
+++ b/lib/modules/homepage/presentation/screens/home_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
@@ -12,11 +12,24 @@ import 'package:vestrollmobile/modules/homepage/presentation/widgets/account_set
 import 'package:vestrollmobile/modules/homepage/presentation/widgets/balance_card.dart';
 import 'package:vestrollmobile/modules/homepage/presentation/widgets/contract_list_item.dart';
 import 'package:vestrollmobile/modules/homepage/presentation/widgets/empty_state_section.dart';
-
 import 'package:vestrollmobile/modules/homepage/presentation/widgets/home_transaction_item.dart';
 import 'package:vestrollmobile/modules/homepage/presentation/widgets/quick_action_section.dart';
 import 'package:vestrollmobile/modules/homepage/presentation/widgets/upcoming_payment_list_item.dart';
 import 'package:vestrollmobile/shared/widgets/bottom_navigation_bar.dart';
+
+// Add this enum if not already defined elsewhere
+enum EmptyStateType {
+  contracts,
+  transactions,
+  payments,
+}
+
+// Add this enum for contract status
+enum ContractStatus {
+  active,
+  pending,
+  expired,
+}
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -41,21 +54,23 @@ class _HomeScreenState extends State<HomeScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Updated Header - removed notification icon (now in balance card)
               _buildHeader(colors, fonts),
               SizedBox(height: 16.h),
+              
+              // Updated Balance Card with notification icon
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: 20.w),
                 child: TotalBalanceCard(
                   balance: 5050.00,
-                  percentageChange: -0.0051,
-                  amountChange: 0.99,
-                  onTap: () {
-                    setState(() {
-                      _isEmpty = !_isEmpty;
-                    });
+                  onNotificationTap: () {
+                    // Handle notification tap
+                    print('Notification tapped');
                   },
                 ),
               ),
+              
+              // Account Setup Card (shows when _isEmpty is true)
               if (_isEmpty) ...[
                 SizedBox(height: 24.h),
                 Padding(
@@ -63,12 +78,14 @@ class _HomeScreenState extends State<HomeScreen> {
                   child: AccountSetupCard(progress: 0.2, onTap: () {}),
                 ),
               ],
+              
               SizedBox(height: 16.h),
+              
+              // Timeline Beta Banner
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: 20.w),
                 child: GestureDetector(
-                  onTap:
-                      () => context.pushNamed(RouteConstants.timelineShowcase),
+                  onTap: () => context.pushNamed(RouteConstants.timelineShowcase),
                   child: Container(
                     padding: EdgeInsets.all(12.sp),
                     decoration: BoxDecoration(
@@ -97,34 +114,47 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                 ),
               ),
+              
               SizedBox(height: 24.h),
+              
+              // Quick Actions Section
               const QuickActionsSection(),
+              
               SizedBox(height: 24.h),
+              
+              // Contracts Section with Empty State
               _buildSection(
                 title: 'Contracts',
                 isEmpty: _isEmpty,
                 onSeeAll: () {},
-                emptyAsset: AppAssets.contractEmpty,
+                type: EmptyStateType.contracts,
                 content: _buildContractsList(colors, fonts),
               ),
+              
               SizedBox(height: 24.h),
+              
+              // Transactions Section with Empty State
               _buildSection(
                 title: 'Transactions',
                 isEmpty: _isEmpty,
                 onSeeAll: () {},
-                emptyAsset: AppAssets.transactionEmpty,
+                type: EmptyStateType.transactions,
                 content: _buildTransactionsList(colors, fonts),
               ),
+              
               SizedBox(height: 24.h),
+              
+              // Upcoming Payments Section
               _buildSection(
                 title: 'Upcoming payments',
                 isEmpty: _isEmpty,
                 onSeeAll: () {
                   context.pushNamed(RouteConstants.upcomingPayments);
                 },
-                emptyAsset: AppAssets.transactionEmpty,
+                type: EmptyStateType.payments,
                 content: _buildUpcomingPaymentsList(colors, fonts),
               ),
+              
               SizedBox(height: 32.h),
             ],
           ),
@@ -143,73 +173,42 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  // Updated Header - removed notification icon
   Widget _buildHeader(
     ColorSystemExtension colors,
     AppFontThemeExtension fonts,
   ) {
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 16.h),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Welcome!',
-                style: fonts.textSmRegular.copyWith(
-                  fontSize: 14.sp,
-                  color: colors.textSecondary,
-                ),
-              ),
-              SizedBox(height: 4.h),
-              Text(
-                'Adebisi Adeyemi',
-                style: fonts.heading2Bold.copyWith(
-                  fontSize: 20.sp,
-                  color: colors.textPrimary,
-                ),
-              ),
-            ],
+          Text(
+            'Welcome!',
+            style: fonts.textSmRegular.copyWith(
+              fontSize: 14.sp,
+              color: colors.textSecondary,
+            ),
           ),
-          Stack(
-            children: [
-              Container(
-                width: 40.w,
-                height: 40.h,
-                decoration: BoxDecoration(
-                  color: colors.bgB0,
-                  borderRadius: BorderRadius.circular(8.r),
-                ),
-                child: Center(
-                  child: SvgPicture.asset(AppAssets.notificationHome),
-                ),
-              ),
-              Positioned(
-                top: 8.h,
-                right: 8.w,
-                child: Container(
-                  width: 8.w,
-                  height: 8.h,
-                  decoration: BoxDecoration(
-                    color: colors.red500,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: colors.bgB0, width: 1.5),
-                  ),
-                ),
-              ),
-            ],
+          SizedBox(height: 4.h),
+          Text(
+            'Adebisi Adeyemi',
+            style: fonts.heading2Bold.copyWith(
+              fontSize: 20.sp,
+              color: colors.textPrimary,
+            ),
           ),
         ],
       ),
     );
   }
 
+  // Updated Section Builder with EmptyStateType
   Widget _buildSection({
     required String title,
     required bool isEmpty,
     required VoidCallback onSeeAll,
-    required String emptyAsset,
+    required EmptyStateType type,
     required Widget content,
   }) {
     final colors = Theme.of(context).extension<ColorSystemExtension>()!;
@@ -226,27 +225,36 @@ class _HomeScreenState extends State<HomeScreen> {
               Text(
                 title,
                 style: fonts.heading3Bold.copyWith(
-                  fontSize: 16.sp,
+                  fontSize: 18.sp,
+                  fontWeight: FontWeight.w600,
                   color: colors.textPrimary,
                 ),
               ),
-              GestureDetector(
+              InkWell(
                 onTap: onSeeAll,
-                child: Row(
-                  children: [
-                    Text(
-                      'See all',
-                      style: fonts.textSmMedium.copyWith(
-                        color: colors.brandContrast,
-                        fontSize: 14.sp,
+                borderRadius: BorderRadius.circular(4.r),
+                splashColor: colors.brandDefault.withOpacity(0.1),
+                highlightColor: colors.brandDefault.withOpacity(0.05),
+                child: Padding(
+                  padding: EdgeInsets.all(8.w),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'See all',
+                        style: fonts.textSmMedium.copyWith(
+                          fontSize: 14.sp,
+                          color: colors.brandDefault,
+                        ),
                       ),
-                    ),
-                    Icon(
-                      Icons.chevron_right,
-                      color: colors.brandContrast,
-                      size: 16.sp,
-                    ),
-                  ],
+                      SizedBox(width: 2.w),
+                      Icon(
+                        Icons.chevron_right,
+                        color: colors.brandDefault,
+                        size: 16.sp,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ],
@@ -255,19 +263,18 @@ class _HomeScreenState extends State<HomeScreen> {
         SizedBox(height: 12.h),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 20.w),
-          child:
-              isEmpty
-                  ? EmptyStateSection(
-                    assetImage: emptyAsset,
-                    title: title,
-                    onSeeAll: onSeeAll,
-                  )
-                  : content,
+          child: isEmpty
+              ? EmptyStateSection(
+                  type: type,
+                  onSeeAll: onSeeAll,
+                )
+              : content,
         ),
       ],
     );
   }
 
+  // Updated Contracts List with ContractStatus enum
   Widget _buildContractsList(
     ColorSystemExtension colors,
     AppFontThemeExtension fonts,
@@ -278,33 +285,34 @@ class _HomeScreenState extends State<HomeScreen> {
           title: 'Weave Finance Mobile &...',
           subtitle: 'Pay As You Go Contract',
           amount: '50 EURt',
-          status: 'Pending',
-          statusColor: colors.orange500,
+          status: ContractStatus.pending,
           initials: 'WF',
           avatarColor: colors.green500,
+          onTap: () {},
         ),
         ContractListItem(
           title: 'Quikdash Mobile & Web...',
           subtitle: 'Milestone Contract',
           amount: '581 STRK',
-          status: 'Pending',
-          statusColor: colors.orange500,
+          status: ContractStatus.pending,
           initials: 'QM',
           avatarColor: colors.orange500,
+          onTap: () {},
         ),
         ContractListItem(
           title: 'VestRoll Mobile & Web...',
           subtitle: 'Fixed Rate Contract',
           amount: '581 USDT',
-          status: 'Active',
-          statusColor: colors.green500,
+          status: ContractStatus.active,
           initials: 'DM',
-          avatarColor: colors.brandContrast,
+          avatarColor: colors.brandContrast ?? Colors.purple,
+          onTap: () {},
         ),
       ],
     );
   }
 
+  // Updated Transactions List - keeping the stacked icons (they're already good)
   Widget _buildTransactionsList(
     ColorSystemExtension colors,
     AppFontThemeExtension fonts,
@@ -317,11 +325,14 @@ class _HomeScreenState extends State<HomeScreen> {
           amount: '- 581 USDT',
           status: 'Processing',
           statusColor: colors.orange500,
+          onTap: () {},
           icon: Stack(
             children: [
               Container(
+                width: 44.w,
+                height: 44.w,
                 decoration: const BoxDecoration(
-                  color: Colors.blue,
+                  color: Color(0xFF3B82F6), // Blue
                   shape: BoxShape.circle,
                 ),
                 child: Center(
@@ -336,15 +347,18 @@ class _HomeScreenState extends State<HomeScreen> {
                 bottom: 2,
                 right: 2,
                 child: Container(
-                  padding: const EdgeInsets.all(2),
+                  width: 18.w,
+                  height: 18.w,
                   decoration: const BoxDecoration(
                     color: Colors.white,
                     shape: BoxShape.circle,
                   ),
-                  child: Icon(
-                    Icons.arrow_upward,
-                    color: Colors.red,
-                    size: 10.sp,
+                  child: Center(
+                    child: Icon(
+                      Icons.arrow_upward,
+                      color: Color(0xFFEF4444), // Red
+                      size: 12.sp,
+                    ),
                   ),
                 ),
               ),
@@ -357,11 +371,14 @@ class _HomeScreenState extends State<HomeScreen> {
           amount: '+ 21 USDC',
           status: 'Successful',
           statusColor: colors.green500,
+          onTap: () {},
           icon: Stack(
             children: [
               Container(
+                width: 44.w,
+                height: 44.w,
                 decoration: const BoxDecoration(
-                  color: Colors.pink,
+                  color: Color(0xFF10B981), // Green
                   shape: BoxShape.circle,
                 ),
                 child: Center(
@@ -372,12 +389,15 @@ class _HomeScreenState extends State<HomeScreen> {
                 bottom: 2,
                 right: 2,
                 child: Container(
-                  padding: const EdgeInsets.all(2),
+                  width: 18.w,
+                  height: 18.w,
                   decoration: const BoxDecoration(
                     color: Colors.white,
                     shape: BoxShape.circle,
                   ),
-                  child: Icon(Icons.check, color: Colors.green, size: 10.sp),
+                  child: Center(
+                    child: Icon(Icons.check, color: Color(0xFF10B981), size: 12.sp),
+                  ),
                 ),
               ),
             ],
@@ -389,11 +409,14 @@ class _HomeScreenState extends State<HomeScreen> {
           amount: '+ 581 USDT',
           status: 'Successful',
           statusColor: colors.green500,
+          onTap: () {},
           icon: Stack(
             children: [
               Container(
+                width: 44.w,
+                height: 44.w,
                 decoration: const BoxDecoration(
-                  color: Colors.orange,
+                  color: Color(0xFFF59E0B), // Orange
                   shape: BoxShape.circle,
                 ),
                 child: Center(
@@ -408,12 +431,15 @@ class _HomeScreenState extends State<HomeScreen> {
                 bottom: 2,
                 right: 2,
                 child: Container(
-                  padding: const EdgeInsets.all(2),
+                  width: 18.w,
+                  height: 18.w,
                   decoration: const BoxDecoration(
                     color: Colors.white,
                     shape: BoxShape.circle,
                   ),
-                  child: Icon(Icons.check, color: Colors.green, size: 10.sp),
+                  child: Center(
+                    child: Icon(Icons.check, color: Color(0xFF10B981), size: 12.sp),
+                  ),
                 ),
               ),
             ],
@@ -423,6 +449,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  // Upcoming Payments List (unchanged)
   Widget _buildUpcomingPaymentsList(
     ColorSystemExtension colors,
     AppFontThemeExtension fonts,
@@ -436,8 +463,9 @@ class _HomeScreenState extends State<HomeScreen> {
           status: 'Overdue',
           statusColor: colors.orange500,
           icon: Icons.account_balance_wallet,
-          iconBackgroundColor: colors.brandContrast,
+          iconBackgroundColor: colors.brandContrast ?? Colors.purple,
           paymentType: PaymentType.contract,
+          onTap: () {},
         ),
         UpcomingPaymentListItem(
           title: 'Neurolytix Initial consul...',
@@ -448,6 +476,7 @@ class _HomeScreenState extends State<HomeScreen> {
           icon: Icons.receipt_long,
           iconBackgroundColor: Colors.orange,
           paymentType: PaymentType.invoice,
+          onTap: () {},
         ),
         UpcomingPaymentListItem(
           title: 'MintForge Bug fixes an...',
@@ -456,8 +485,9 @@ class _HomeScreenState extends State<HomeScreen> {
           status: 'Overdue',
           statusColor: colors.orange500,
           icon: Icons.account_balance_wallet,
-          iconBackgroundColor: colors.brandContrast,
+          iconBackgroundColor: colors.brandContrast ?? Colors.purple,
           paymentType: PaymentType.contract,
+          onTap: () {},
         ),
       ],
     );

--- a/lib/modules/homepage/presentation/widgets/account_setup_card.dart
+++ b/lib/modules/homepage/presentation/widgets/account_setup_card.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: deprecated_member_use
+ // ignore_for_file: deprecated_member_use
 
 import 'dart:ui';
 import 'package:flutter/material.dart';
@@ -19,11 +19,22 @@ class AccountSetupCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
+      behavior: HitTestBehavior.opaque,
       child: Container(
-        height: 104.h,
         decoration: BoxDecoration(
-          color: colors.brandDefault,
+          gradient: const LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFF7C3AED), Color(0xFF6D28D9)], // Purple gradient
+          ),
           borderRadius: BorderRadius.circular(16.r),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
         ),
         padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 16.h),
         child: Row(
@@ -34,19 +45,19 @@ class AccountSetupCard extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    'Complete Account Setup',
+                    'Finish setting up...',
                     style: fonts.heading3Bold.copyWith(
                       fontSize: 16.sp,
-                      color: colors.constantContrast,
+                      color: Colors.white,
+                      fontWeight: FontWeight.w500,
                     ),
                   ),
-                  SizedBox(height: 6.h),
+                  SizedBox(height: 4.h),
                   Text(
-                    'Finish setting up your account to start\nsending invoices and signing contracts.',
+                    'Complete your profile to get started',
                     style: fonts.textSmRegular.copyWith(
                       fontSize: 12.sp,
-                      color: colors.constantContrast.withOpacity(0.9),
-                      height: 1.4,
+                      color: Colors.white.withOpacity(0.8),
                     ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
@@ -56,29 +67,27 @@ class AccountSetupCard extends StatelessWidget {
             ),
             SizedBox(width: 16.w),
             SizedBox(
-              width: 56.w,
-              height: 56.h,
+              width: 44.w,
+              height: 44.w,
               child: Stack(
                 alignment: Alignment.center,
                 children: [
                   SizedBox(
-                    width: 56.w,
-                    height: 56.h,
+                    width: 44.w,
+                    height: 44.w,
                     child: CircularProgressIndicator(
                       value: progress,
-                      strokeWidth: 4.w,
-                      valueColor: AlwaysStoppedAnimation<Color>(
-                        colors.constantContrast,
-                      ),
-                      backgroundColor: colors.constantContrast.withOpacity(0.3),
+                      strokeWidth: 3,
+                      valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+                      backgroundColor: Colors.white.withOpacity(0.3),
                       strokeCap: StrokeCap.round,
                     ),
                   ),
                   Text(
                     '${(progress * 100).toInt()}%',
                     style: fonts.textSmBold.copyWith(
-                      fontSize: 13.sp,
-                      color: colors.constantContrast,
+                      fontSize: 12.sp,
+                      color: Colors.white,
                     ),
                   ),
                 ],

--- a/lib/modules/homepage/presentation/widgets/balance_card.dart
+++ b/lib/modules/homepage/presentation/widgets/balance_card.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: deprecated_member_use
+ // ignore_for_file: deprecated_member_use
 
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -7,16 +7,12 @@ import 'package:vestrollmobile/core/utils/themes_colors/app_font_theme_extension
 
 class TotalBalanceCard extends StatelessWidget {
   final double balance;
-  final double percentageChange;
-  final double amountChange;
-  final VoidCallback? onTap;
+  final VoidCallback? onNotificationTap;
 
   const TotalBalanceCard({
     super.key,
     this.balance = 0.00,
-    this.percentageChange = 0.00,
-    this.amountChange = 0.00,
-    this.onTap,
+    this.onNotificationTap,
   });
 
   @override
@@ -24,55 +20,76 @@ class TotalBalanceCard extends StatelessWidget {
     final colors = Theme.of(context).extension<ColorSystemExtension>()!;
     final fonts = Theme.of(context).extension<AppFontThemeExtension>()!;
 
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: EdgeInsets.all(20.w),
-        decoration: BoxDecoration(
-          color:
-              colors
-                  .bgB0, // Figma shows it as slightly off-white or white with a light border
-          borderRadius: BorderRadius.circular(16.r),
-          border: Border.all(color: colors.strokePrimary.withOpacity(0.5)),
-        ),
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Total balance',
-                    style: fonts.textSmRegular.copyWith(
-                      fontSize: 14.sp,
-                      color: colors.textSecondary,
-                    ),
-                  ),
-                  SizedBox(height: 8.h),
-                  Text(
-                    '\$${balance.toStringAsFixed(2).replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
-                    style: fonts.heading1Bold.copyWith(
-                      fontSize: 32.sp,
-                      color: colors.textPrimary,
-                    ),
-                  ),
-                  SizedBox(height: 6.h),
-                  Text(
-                    '${percentageChange < 0 ? '-' : '+'}${percentageChange.abs().toStringAsFixed(4)}% (\$${amountChange.toStringAsFixed(2)})',
-                    style: fonts.textSmMedium.copyWith(
-                      fontSize: 14.sp,
-                      color:
-                          percentageChange < 0
-                              ? colors.red500
-                              : colors.green500,
-                    ),
-                  ),
-                ],
+    return Container(
+      padding: EdgeInsets.all(20.w),
+      decoration: BoxDecoration(
+        color: colors.bgB0,
+        borderRadius: BorderRadius.circular(16.r),
+        border: Border.all(color: colors.strokePrimary.withOpacity(0.5)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Total balance',
+                style: fonts.textSmRegular.copyWith(
+                  fontSize: 14.sp,
+                  color: colors.textSecondary,
+                  fontWeight: FontWeight.w400,
+                  letterSpacing: 0.25,
+                ),
               ),
+              SizedBox(height: 4.h),
+              Text(
+                '\$${balance.toStringAsFixed(2).replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                style: fonts.heading1Bold.copyWith(
+                  fontSize: 28.sp,
+                  fontWeight: FontWeight.w600,
+                  color: colors.textPrimary,
+                  letterSpacing: -0.5,
+                ),
+              ),
+            ],
+          ),
+          GestureDetector(
+            onTap: onNotificationTap,
+            behavior: HitTestBehavior.opaque,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Container(
+                  width: 40.w,
+                  height: 40.w,
+                  decoration: BoxDecoration(
+                    color: colors.bgB1,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.notifications_outlined,
+                    color: colors.textSecondary,
+                    size: 20.w,
+                  ),
+                ),
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: Container(
+                    width: 10.w,
+                    height: 10.w,
+                    decoration: BoxDecoration(
+                      color: colors.red500,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 2),
+                    ),
+                  ),
+                ),
+              ],
             ),
-            Icon(Icons.chevron_right, color: colors.textSecondary, size: 24.sp),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/modules/homepage/presentation/widgets/contract_list_item.dart
+++ b/lib/modules/homepage/presentation/widgets/contract_list_item.dart
@@ -1,14 +1,19 @@
-import 'package:flutter/material.dart';
+ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:vestrollmobile/core/utils/themes_colors/app_color_extension.dart';
 import 'package:vestrollmobile/core/utils/themes_colors/app_font_theme_extension.dart';
+
+enum ContractStatus {
+  active,
+  pending,
+  expired,
+}
 
 class ContractListItem extends StatelessWidget {
   final String title;
   final String subtitle;
   final String amount;
-  final String status;
-  final Color statusColor;
+  final ContractStatus status;
   final String initials;
   final Color avatarColor;
   final VoidCallback? onTap;
@@ -19,11 +24,32 @@ class ContractListItem extends StatelessWidget {
     required this.subtitle,
     required this.amount,
     required this.status,
-    required this.statusColor,
     required this.initials,
     required this.avatarColor,
     this.onTap,
   });
+
+  Color _getStatusColor() {
+    switch (status) {
+      case ContractStatus.active:
+        return const Color(0xFF10B981); // Active green
+      case ContractStatus.pending:
+        return const Color(0xFFF59E0B); // Pending orange
+      case ContractStatus.expired:
+        return const Color(0xFFEF4444); // Expired red
+    }
+  }
+
+  String _getStatusText() {
+    switch (status) {
+      case ContractStatus.active:
+        return 'Active';
+      case ContractStatus.pending:
+        return 'Pending';
+      case ContractStatus.expired:
+        return 'Expired';
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,17 +64,17 @@ class ContractListItem extends StatelessWidget {
         child: Row(
           children: [
             Container(
-              width: 48.w,
-              height: 48.h,
+              width: 44.w,
+              height: 44.w,
               decoration: BoxDecoration(
-                color: avatarColor,
-                shape: BoxShape.circle,
+                color: avatarColor.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(8.r),
               ),
               child: Center(
                 child: Text(
                   initials,
                   style: fonts.textMdBold.copyWith(
-                    color: colors.constantContrast,
+                    color: avatarColor,
                     fontSize: 16.sp,
                   ),
                 ),
@@ -63,7 +89,7 @@ class ContractListItem extends StatelessWidget {
                     title,
                     style: fonts.textMdSemiBold.copyWith(
                       color: colors.textPrimary,
-                      fontSize: 15.sp,
+                      fontSize: 16.sp,
                     ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
@@ -72,8 +98,8 @@ class ContractListItem extends StatelessWidget {
                   Text(
                     subtitle,
                     style: fonts.textSmRegular.copyWith(
-                      color: colors.textTertiary,
-                      fontSize: 13.sp,
+                      color: colors.textSecondary,
+                      fontSize: 14.sp,
                     ),
                   ),
                 ],
@@ -87,30 +113,24 @@ class ContractListItem extends StatelessWidget {
                   amount,
                   style: fonts.textMdBold.copyWith(
                     color: colors.textPrimary,
-                    fontSize: 15.sp,
+                    fontSize: 16.sp,
                   ),
                 ),
                 SizedBox(height: 4.h),
-                Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Container(
-                      width: 6.w,
-                      height: 6.h,
-                      decoration: BoxDecoration(
-                        color: statusColor,
-                        shape: BoxShape.circle,
-                      ),
+                Container(
+                  padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 2.h),
+                  decoration: BoxDecoration(
+                    color: _getStatusColor().withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(4.r),
+                  ),
+                  child: Text(
+                    _getStatusText(),
+                    style: fonts.textSmMedium.copyWith(
+                      color: _getStatusColor(),
+                      fontSize: 12.sp,
+                      fontWeight: FontWeight.w500,
                     ),
-                    SizedBox(width: 4.w),
-                    Text(
-                      status,
-                      style: fonts.textSmMedium.copyWith(
-                        color: statusColor,
-                        fontSize: 13.sp,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ],
             ),

--- a/lib/modules/homepage/presentation/widgets/empty_state_section.dart
+++ b/lib/modules/homepage/presentation/widgets/empty_state_section.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: deprecated_member_use
+ // ignore_for_file: deprecated_member_use
 
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -6,18 +6,54 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:vestrollmobile/core/utils/themes_colors/app_color_extension.dart';
 import 'package:vestrollmobile/core/utils/themes_colors/app_font_theme_extension.dart';
 
+enum EmptyStateType {
+  contracts,
+  transactions,
+  payments,
+}
+
 class EmptyStateSection extends StatelessWidget {
-  final String title;
+  final EmptyStateType type;
   final VoidCallback onSeeAll;
-  final String assetImage;
 
   const EmptyStateSection({
-    required this.title,
+    required this.type,
     required this.onSeeAll,
-    required this.assetImage,
-
     super.key,
   });
+
+  String _getAssetPath() {
+    switch (type) {
+      case EmptyStateType.contracts:
+        return 'assets/illustrations/empty_contracts.svg';
+      case EmptyStateType.transactions:
+        return 'assets/illustrations/empty_transactions.svg';
+      case EmptyStateType.payments:
+        return 'assets/illustrations/empty_payments.svg';
+    }
+  }
+
+  String _getTitle() {
+    switch (type) {
+      case EmptyStateType.contracts:
+        return 'Contracts';
+      case EmptyStateType.transactions:
+        return 'Transactions';
+      case EmptyStateType.payments:
+        return 'Payments';
+    }
+  }
+
+  String _getMessage() {
+    switch (type) {
+      case EmptyStateType.contracts:
+        return 'No contracts yet. Create your first contract.';
+      case EmptyStateType.transactions:
+        return 'Transactions will appear here';
+      case EmptyStateType.payments:
+        return 'No payments yet';
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,66 +69,82 @@ class EmptyStateSection extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                title,
+                _getTitle(),
                 style: fonts.heading3Bold.copyWith(
-                  fontSize: 14.sp,
-                  fontWeight: FontWeight.bold,
+                  fontSize: 18.sp,
+                  fontWeight: FontWeight.w600,
                   color: colors.textPrimary,
                 ),
               ),
-              GestureDetector(
+              InkWell(
                 onTap: onSeeAll,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      'See all',
-                      style: fonts.textSmMedium.copyWith(
-                        fontSize: 12.sp,
-                        color: colors.brandDefault,
+                borderRadius: BorderRadius.circular(4.r),
+                child: Padding(
+                  padding: EdgeInsets.all(8.w),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'See all',
+                        style: fonts.textSmMedium.copyWith(
+                          fontSize: 14.sp,
+                          color: colors.brandDefault,
+                        ),
                       ),
-                    ),
-                    SizedBox(width: 4.w),
-                    Icon(
-                      Icons.chevron_right,
-                      color: colors.brandDefault,
-                      size: 16.sp,
-                    ),
-                  ],
+                      SizedBox(width: 2.w),
+                      Icon(
+                        Icons.chevron_right,
+                        color: colors.brandDefault,
+                        size: 16.sp,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ],
           ),
         ),
-        SizedBox(height: 8.h),
+        SizedBox(height: 12.h),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 20.w),
           child: Container(
             width: double.infinity,
-            height: 156.h,
+            padding: EdgeInsets.all(24.w),
             decoration: BoxDecoration(
               color: colors.bgB0,
               borderRadius: BorderRadius.circular(12.r),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withOpacity(0.04),
+                  color: Colors.black.withOpacity(0.03),
                   blurRadius: 8,
-                  offset: Offset(0, 2),
+                  offset: const Offset(0, 2),
                 ),
               ],
             ),
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                SvgPicture.asset(assetImage, width: 64.sp),
-
+                SvgPicture.asset(
+                  _getAssetPath(),
+                  width: 120.w,
+                  height: 120.w,
+                  placeholderBuilder: (context) => Container(
+                    width: 120.w,
+                    height: 120.w,
+                    color: Colors.grey[200],
+                    child: const Center(
+                      child: Icon(Icons.image_not_supported_outlined),
+                    ),
+                  ),
+                ),
                 SizedBox(height: 16.h),
                 Text(
-                  '$title will appear here',
+                  _getMessage(),
                   style: fonts.textSmRegular.copyWith(
-                    fontSize: 16.sp,
+                    fontSize: 14.sp,
                     color: colors.textSecondary,
+                    height: 1.5,
                   ),
+                  textAlign: TextAlign.center,
                 ),
               ],
             ),


### PR DESCRIPTION
- Update AccountSetupCard with purple gradient and 'Finish setting up...' text
- Enhance BalanceCard with notification icon and red dot, fix typography
- Add status chips to ContractListItem with brand colors (Active: #10B981, Pending: #F59E0B)
- Improve EmptyStateSection with proper SVG illustrations and container styling
- Move notification icon from header to balance card
- Ensure consistent 20.w padding and spacing
- Add tap feedback to all interactive elements

Closes #41